### PR TITLE
Migrate from blue to core CI Jenkins instance

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,11 @@
 pipeline {
-    agent any
-    tools { nodejs 'node-v6.10.3' }
+    agent {
+      label 'crew-apollo' // Run only on agents under this label
+    }
+    tools {
+      // Make sure Jenkins supports the version below. If not, contact #crew-bronn
+      nodejs 'node-v6.10.3'
+    }
     stages {
         stage('Checkout') {
           steps {
@@ -10,7 +15,9 @@ pipeline {
 
         stage('Installing dependencies') {
             steps {
-                sh 'yarn'
+                sshagent(['auth0extensions-ssh-key']) {
+                    sh 'yarn'
+                }
             }
         }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,7 +20,7 @@ pipeline {
           }
         }
 
-        stage('Build') { 
+        stage('Build') {
             steps {
                 sh 'npm run build'
             }
@@ -30,16 +30,16 @@ pipeline {
             steps {
                 sh 'tools/cdn.sh'
             }
-        }    
+        }
     }
 
     post {
       // Always runs. And it runs before any of the other post conditions.
       always {
-        // Let's wipe out the workspace before we finish!        
+        // Let's wipe out the workspace before we finish!
         deleteDir()
       }
-      
+
       success {
         slackSend channel: '#crew-apollo-build',
                   color: 'good',
@@ -59,7 +59,7 @@ pipeline {
       // For example, we'd like to make sure we only keep 10 builds at a time, so
       // we don't fill up our storage!
       buildDiscarder(logRotator(numToKeepStr:'10'))
-      
+
       // And we'd really like to be sure that this build doesn't hang forever, so
       // let's time it out after an hour.
       timeout(time: 30, unit: 'MINUTES')


### PR DESCRIPTION
Make required changes for this repo to be tested by core jenkins CI instance

We are migrating all jenkins jobs from our blue instance to our core jenkins CI
instance.  This requires that we..

1. Run on a specified jenkins agent for the owning team
2. Use the `sshagent` wrapper to get access to git credentials

After this change is reviewed and merged, we will create a new jenkins pipeline
job for it on the core jenkins CI instance, currently hosted at
https://tools-jenkins-us-west-2.forge.auth0.net .  When that happens, it will
automatically run a build against the master branch. This will cause the publish
step to execute and we will need to confirm that it does not break anything
downstream and that it runs correctly.